### PR TITLE
Refactor for production release

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ cd OnionChat
 ```
 
 
-The codebase is organized into multiple modules: `client_a.py`, `client_b.py`, and `chat_utils.py` provide the core functionality while `main.py` remains the entry point.
+The codebase is organized into multiple modules. `client_a_main.py` and `client_b_main.py` provide separate entry points for each client, while `client_a.py`, `client_b.py`, and `chat_utils.py` hold the shared logic.
 ## Usage 🎮
 
 ### Running Client A 🎤
 Client A hosts the chat session and generates credentials (onion address, session ID, public key, and QR code).
 
 ```bash
-python main.py client_a [--port PORT] [--timeout SECONDS] [--padding BYTES] [--max-file-size MB] [--tor-impl {torpy,stem}]
+python client_a_main.py [--port PORT] [--timeout SECONDS] [--padding BYTES] [--max-file-size MB] [--tor-impl {torpy,stem}]
 ```
 
 - **Options** ⚙️:
@@ -62,7 +62,7 @@ python main.py client_a [--port PORT] [--timeout SECONDS] [--padding BYTES] [--m
 Client B connects to Client A’s session using the shared credentials.
 
 ```bash
-python main.py client_b [<onion_hostname> <session_id> <public_key_file>] [--port PORT] [--timeout SECONDS] [--padding BYTES] [--max-file-size MB] [--tor-impl {torpy,stem}]
+python client_b_main.py [<onion_hostname> <session_id> <public_key_file>] [--port PORT] [--timeout SECONDS] [--padding BYTES] [--max-file-size MB] [--tor-impl {torpy,stem}]
 ```
 
 - **Options**: Same as Client A.
@@ -95,29 +95,38 @@ OnionChat can be compiled into standalone executables for Linux, Windows, and ma
 ```
 
    ```
-2. **Compile the Binary**:
-   - Run the following command in the repository directory:
+2. **Compile the Binaries**:
+   - Build Client A:
      ```bash
-     pyinstaller --onefile main.py
+     pyinstaller --onefile client_a_main.py
      ```
-   - The binary will be created in the `dist/` directory (e.g., `dist/main` on Linux/macOS, `dist/main.exe` on Windows).
+     This creates `dist/client_a_main` (`client_a.exe` on Windows).
+   - Build Client B:
+     ```bash
+     pyinstaller --onefile client_b_main.py
+     ```
+     This creates `dist/client_b_main` (`client_b.exe` on Windows).
 3. **Platform-Specific Notes**:
    - **Linux** 🐧:
-     - Requires `python3-tk` for Tkinter (e.g., `sudo apt install python3-tk` on Debian/Ubuntu).
+     - Requires `python3-tk` for Tkinter (e.g., `sudo apt install python3-tk`).
      - Ensure X11 or another graphical environment is running.
-     - Test the binary: `./dist/main client_a`.
+     - Test Client A: `./dist/client_a_main`.
+     - Test Client B: `./dist/client_b_main`.
    - **Windows** 🪟:
      - Tkinter is included with Python; no additional setup needed.
-     - Run the binary: `dist\main.exe client_a`.
+     - Run Client A: `dist\client_a_main.exe`.
+     - Run Client B: `dist\client_b_main.exe`.
      - If compiling on another platform for Windows, use Wine or a Windows VM, or specify `--target-architecture x64`.
    - **macOS** 🍎:
      - Tkinter is included with Python; ensure a Python version from python.org or Homebrew for best compatibility.
-     - Run the binary: `./dist/main client_a`.
-     - macOS may require signing the binary for Gatekeeper: `codesign -f -s - dist/main`.
-4. **Distribute the Binary** 📤:
-   - Copy the binary (`dist/main` or `dist/main.exe`) to the target machine.
+     - Run Client A: `./dist/client_a_main`.
+     - Run Client B: `./dist/client_b_main`.
+     - macOS may require signing the binaries for Gatekeeper: `codesign -f -s - dist/client_a_main`.
+4. **Distribute the Binaries** 📤:
+   - Copy `dist/client_a_main*` and/or `dist/client_b_main*` to the target machine.
    - Ensure the target machine has a graphical environment and internet access for Tor connectivity.
    - No Python or dependencies need to be installed on the target machine.
+   - Test each executable on a clean system to confirm it launches without additional files.
 
 ### Troubleshooting Compilation ⚠️
 - **Large Binary Size**: The binary includes Python, Tkinter, `torpy`, `cryptography`, and other dependencies, resulting in ~60-80 MB. Use `--strip` to reduce size slightly, but expect large binaries due to OpenCV and Pillow.
@@ -127,11 +136,11 @@ OnionChat can be compiled into standalone executables for Linux, Windows, and ma
 
 ## Example Workflow 🚀
 1. **Client A**:
-   - Run: `python main.py client_a` or `./dist/main client_a`
+   - Run: `python client_a_main.py` or `./dist/client_a_main`
    - GUI shows credentials and QR code. Enter a passphrase (e.g., "mysecret123"). 🔐
    - Copy clipboard data or display QR code for Client B.
 2. **Client B**:
-   - Run: `python main.py client_b` or `./dist/main client_b`
+   - Run: `python client_b_main.py` or `./dist/client_b_main`
    - In the setup GUI, click "Scan QR Code" (use webcam or select image) or enter credentials manually. 📷
    - Enter the passphrase ("mysecret123").
    - Click "Connect" to start chatting.
@@ -143,7 +152,10 @@ OnionChat can be compiled into standalone executables for Linux, Windows, and ma
 - **Anonymity**: Tor hidden services hide IP addresses, with ephemeral `.onion` addresses. 🕵️
 - **QR Code Security**: Credentials encrypted with AES-256-GCM using a passphrase, displayed in-memory to avoid disk storage. 📷
 - **Ephemerality**: No message or key storage, ensuring no forensic recovery. ⏳
-- **Timeout and Kill Switch**: Prevents prolonged exposure and unauthorized reconnection. ⏰🛑
+  - **Timeout and Kill Switch**: Prevents prolonged exposure and unauthorized reconnection. ⏰🛑
+
+### Threat Model
+OnionChat assumes both clients control their local machines and network connections. It defends against passive network observers and interception of chat traffic. It does not protect against malware on either client, side-channel attacks, or compromise of the Tor network. If an attacker obtains the session QR data and passphrase before the session ends, they could impersonate a client. Keys are kept in memory only, but Python cannot guarantee perfect erasure.
 
 ## Limitations ⚠️
 - Requires a graphical environment for the GUI and QR code display.

--- a/chat_utils.py
+++ b/chat_utils.py
@@ -38,7 +38,7 @@ except Exception:  # pragma: no cover - optional dependency
 # Wipe sensitive data from memory
 # Best-effort; due to Python memory management this cannot guarantee removal.
 def secure_wipe(data):
-    """Attempt to overwrite and delete sensitive bytes."""
+    """Best-effort overwrite of sensitive data."""
     if data is None:
         return
     try:
@@ -46,6 +46,9 @@ def secure_wipe(data):
             ba = bytearray(data)
         else:
             ba = data
+        rnd = secrets.token_bytes(len(ba))
+        for i in range(len(ba)):
+            ba[i] = rnd[i]
         for i in range(len(ba)):
             ba[i] = 0
     except Exception:

--- a/client_a.py
+++ b/client_a.py
@@ -32,8 +32,12 @@ def client_a_main(args):
     with open("client_a_public_key.pem", "wb") as f:
         f.write(rsa_public_bytes)
 
+    status = tk.Label(root, text="Starting Tor, please wait...")
+    status.pack(pady=5)
+    root.update()
     try:
         tor, onion, onion_hostname = setup_hidden_service(args.port, args.tor_impl == "stem")
+        status.config(text="Tor started")
     except Exception as e:
         messagebox.showerror("Error", f"Failed to create hidden service: {e}")
         root.destroy()
@@ -58,6 +62,7 @@ def client_a_main(args):
     chat_display.pack(pady=10)
     message_entry = tk.Entry(root, width=50)
     message_entry.pack(pady=5)
+    message_entry.bind("<Return>", lambda _: send_message())
 
     server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -186,7 +191,7 @@ def client_a_main(args):
     def send_file():
         nonlocal last_activity
         file_path = filedialog.askopenfilename()
-        if not file_path:
+        if not file_path or not os.path.isfile(file_path):
             return
         if os.path.getsize(file_path) > args.max_file_size * 1024 * 1024:
             messagebox.showerror(

--- a/client_a_main.py
+++ b/client_a_main.py
@@ -1,0 +1,19 @@
+"""Entry script for OnionChat Client A."""
+import argparse
+from client_a import client_a_main
+
+
+def parse_args(argv=None):
+    """Parse CLI arguments for Client A."""
+    parser = argparse.ArgumentParser(description="Run OnionChat Client A")
+    parser.add_argument("--port", type=int, default=12345, help="Port for hidden service")
+    parser.add_argument("--timeout", type=int, default=600, help="Session timeout in seconds")
+    parser.add_argument("--padding", type=int, default=1024, help="Message padding length")
+    parser.add_argument("--max-file-size", type=int, default=100, help="Maximum file size in MB")
+    parser.add_argument("--tor-impl", choices=["torpy", "stem"], default="torpy", help="Tor implementation")
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    client_a_main(args)

--- a/client_b.py
+++ b/client_b.py
@@ -50,9 +50,13 @@ def client_b_main(onion_hostname: str, session_id: str, public_key_file: str, ar
         ),
     )
 
+    status = tk.Label(root, text="Connecting to Tor service...")
+    status.pack(pady=5)
+    root.update()
     try:
         tor = TorClient()
         conn = tor.connect(onion_hostname, 80)
+        status.config(text="Connected")
     except Exception as e:
         messagebox.showerror("Error", f"Failed to connect to Tor service: {e}")
         secure_wipe(ecdh_private_key.private_bytes(
@@ -85,6 +89,7 @@ def client_b_main(onion_hostname: str, session_id: str, public_key_file: str, ar
     chat_display.pack(pady=10)
     message_entry = tk.Entry(root, width=50)
     message_entry.pack(pady=5)
+    message_entry.bind("<Return>", lambda _: send_message())
 
     def receive_messages():
         receiving_file = False
@@ -187,7 +192,7 @@ def client_b_main(onion_hostname: str, session_id: str, public_key_file: str, ar
 
     def send_file():
         file_path = filedialog.askopenfilename()
-        if not file_path:
+        if not file_path or not os.path.isfile(file_path):
             return
         if os.path.getsize(file_path) > args.max_file_size * 1024 * 1024:
             messagebox.showerror(

--- a/client_b_main.py
+++ b/client_b_main.py
@@ -1,0 +1,23 @@
+"""Entry script for OnionChat Client B."""
+import argparse
+from client_b import client_b_main, client_b_setup
+
+
+def parse_args(argv=None):
+    """Parse CLI arguments for Client B."""
+    parser = argparse.ArgumentParser(description="Run OnionChat Client B")
+    parser.add_argument("--onion", help="Onion address")
+    parser.add_argument("--session", help="Session ID")
+    parser.add_argument("--key", help="Public key file")
+    parser.add_argument("--padding", type=int, default=1024, help="Message padding length")
+    parser.add_argument("--max-file-size", type=int, default=100, help="Maximum file size in MB")
+    parser.add_argument("--tor-impl", choices=["torpy", "stem"], default="torpy", help="Tor implementation")
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    if args.onion and args.session and args.key:
+        client_b_main(args.onion, args.session, args.key, args)
+    else:
+        client_b_setup(args)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-torpy
-cryptography
-qrcode
-pyzbar
-opencv-python
-Pillow
-pyperclip
+torpy==1.1.5
+cryptography==41.0.3
+qrcode==7.4.2
+pyzbar==0.1.9
+opencv-python==4.8.1.78
+Pillow==10.0.0
+pyperclip==1.8.2

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,0 +1,26 @@
+import sys
+import os
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+from chat_utils import encrypt_message, decrypt_message, secure_wipe
+
+
+def test_encrypt_message_too_long():
+    key = b"0" * 32
+    with pytest.raises(ValueError):
+        encrypt_message("a" * 2000, key, 32)
+
+
+def test_secure_wipe():
+    data = bytearray(b"secret")
+    secure_wipe(data)
+    assert all(b == 0 for b in data)
+
+
+def test_cli_parsing():
+    import client_a_main
+    args = client_a_main.parse_args([])
+    assert args.port == 12345


### PR DESCRIPTION
## Summary
- add dedicated entry points `client_a_main.py` and `client_b_main.py`
- pin dependency versions
- enhance secure memory wipe and GUI feedback
- support keyboard send and basic input validation
- expand docs for building two executables and add threat model section
- add edge case tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867e4590ca88332bdb0e02a8521eb0c