### PR TITLE
Remove unnecessary nonlocal in timeout check

### DIFF
--- a/client_a.py
+++ b/client_a.py
@@ -222,7 +222,6 @@ def client_a_main(args):
             messagebox.showerror("Error", f"File transfer failed: {e}")
 
     def check_timeout():
-        nonlocal last_activity
         if conn and time.time() - last_activity > args.timeout:
             signature = rsa_private.sign(
                 b"TERMINATE",


### PR DESCRIPTION
## Summary
- fix `check_timeout` in `client_a.py` by removing unused `nonlocal` statement
- run linting and unit tests

## Testing
- `flake8 client_a.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b924d63608332b08a3661a0761bc6