### PR TITLE
Use temp file for Client A public key

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ python client_a_main.py [--port PORT] [--timeout SECONDS] [--padding BYTES] [--m
   - `--padding`: Message padding length in bytes (default: 1024).
   - `--max-file-size`: Maximum file size in megabytes for transfer (default: 100).
   - `--tor-impl`: Use `torpy` (default) or `stem` + Tor for networking.
-- **Output**: A GUI window displays the onion address, session ID, public key file (`client_a_public_key.pem`), and QR code. Enter a passphrase to encrypt the QR code data. Click "Copy QR Data" to copy the encrypted credentials to the clipboard. 📋
+- **Output**: A GUI window displays the onion address, session ID, a temporary public key file path, and a QR code. Enter a passphrase to encrypt the QR code data. Click "Copy QR Data" to copy the encrypted credentials to the clipboard. 📋
 - **Share**: Share the QR code (displayed in GUI) or clipboard data with Client B via a secure channel (e.g., in-person scan, encrypted messaging). 🔐
 
 ### Running Client B 🎧

--- a/client_a.py
+++ b/client_a.py
@@ -1,5 +1,6 @@
 """GUI and logic for hosting an OnionChat session (Client A)."""
 import os
+import tempfile
 import socket
 import threading
 import time
@@ -30,8 +31,10 @@ def client_a_main(args):
     root.geometry("600x400")
 
     rsa_private, _, rsa_public_bytes, ecdh_private, ecdh_public_bytes = generate_keys()
-    with open("client_a_public_key.pem", "wb") as f:
-        f.write(rsa_public_bytes)
+    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".pem")
+    temp_file.write(rsa_public_bytes)
+    temp_file.close()
+    public_key_path = temp_file.name
 
     status = tk.Label(root, text="Starting Tor, please wait...")
     status.pack(pady=5)
@@ -48,7 +51,10 @@ def client_a_main(args):
 
     info_label = tk.Label(
         root,
-        text=f"Onion: {onion_hostname}\nSession ID: {session_id}\nPublic Key: client_a_public_key.pem\nQR Data: Copied to clipboard",
+        text=(
+            f"Onion: {onion_hostname}\nSession ID: {session_id}\n"
+            f"Public Key: {public_key_path}\nQR Data: Copied to clipboard"
+        ),
     )
     info_label.pack(pady=10)
 
@@ -172,7 +178,7 @@ def client_a_main(args):
                 serialization.NoEncryption(),
             ))
             try:
-                os.remove("client_a_public_key.pem")
+                os.remove(public_key_path)
             except Exception:
                 pass
             root.destroy()
@@ -248,7 +254,7 @@ def client_a_main(args):
                 serialization.NoEncryption(),
             ))
             try:
-                os.remove("client_a_public_key.pem")
+                os.remove(public_key_path)
             except Exception:
                 pass
             messagebox.showinfo("Info", "Session timed out")


### PR DESCRIPTION
## Summary
- store Client A's public key in a NamedTemporaryFile
- display the temp file path in the GUI
- remove the temporary file on exit or timeout
- mention the temporary public key file in the README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bb0bc8d408332bbf41c26bba8ebc2