### PR TITLE
Handle public key via temp file

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ python client_a_main.py [--port PORT] [--timeout SECONDS] [--padding BYTES] [--m
   - `--padding`: Message padding length in bytes (default: 1024).
   - `--max-file-size`: Maximum file size in megabytes for transfer (default: 100).
   - `--tor-impl`: Use `torpy` (default) or `stem` + Tor for networking.
-- **Output**: A GUI window displays the onion address, session ID, public key file (`client_a_public_key.pem`), and QR code. Enter a passphrase to encrypt the QR code data. Click "Copy QR Data" to copy the encrypted credentials to the clipboard. 📋
+  - **Output**: A GUI window displays the onion address, session ID, a temporary public key file path, and a QR code. Enter a passphrase to encrypt the QR code data. Click "Copy QR Data" to copy the encrypted credentials to the clipboard. 📋
 - **Share**: Share the QR code (displayed in GUI) or clipboard data with Client B via a secure channel (e.g., in-person scan, encrypted messaging). 🔐
 
 ### Running Client B 🎧

--- a/client_a.py
+++ b/client_a.py
@@ -3,6 +3,7 @@ import os
 import socket
 import threading
 import time
+import tempfile
 import tkinter as tk
 from tkinter import messagebox, filedialog
 from tkinter.scrolledtext import ScrolledText
@@ -30,8 +31,9 @@ def client_a_main(args):
     root.geometry("600x400")
 
     rsa_private, _, rsa_public_bytes, ecdh_private, ecdh_public_bytes = generate_keys()
-    with open("client_a_public_key.pem", "wb") as f:
-        f.write(rsa_public_bytes)
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".pem") as tmp:
+        tmp.write(rsa_public_bytes)
+        public_key_path = tmp.name
 
     status = tk.Label(root, text="Starting Tor, please wait...")
     status.pack(pady=5)
@@ -48,7 +50,12 @@ def client_a_main(args):
 
     info_label = tk.Label(
         root,
-        text=f"Onion: {onion_hostname}\nSession ID: {session_id}\nPublic Key: client_a_public_key.pem\nQR Data: Copied to clipboard",
+        text=(
+            f"Onion: {onion_hostname}\n"
+            f"Session ID: {session_id}\n"
+            f"Public Key: {public_key_path}\n"
+            "QR Data: Copied to clipboard"
+        ),
     )
     info_label.pack(pady=10)
 
@@ -176,7 +183,7 @@ def client_a_main(args):
             )
         )
         try:
-            os.remove("client_a_public_key.pem")
+            os.remove(public_key_path)
         except Exception:
             pass
         root.destroy()
@@ -261,7 +268,7 @@ def client_a_main(args):
                 serialization.NoEncryption(),
             ))
             try:
-                os.remove("client_a_public_key.pem")
+                os.remove(public_key_path)
             except Exception:
                 pass
             messagebox.showinfo("Info", "Session timed out")


### PR DESCRIPTION
## Summary
- create temporary public key file in `client_a.py`
- display temp file path in Client A GUI
- remove the temp file on exit or timeout
- update README to mention temporary public key path

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bb96210b88332adb7325e39af297e