### PR TITLE
Add packaging support with console scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ pip install -r requirements.txt
 
 All dependencies must be installed before running OnionChat.
 
+### Install via `pip`
+If you prefer using `pip`, the project can be installed as a package after cloning:
+```bash
+git clone https://github.com/<your-username>/OnionChat.git
+cd OnionChat
+pip install .
+```
+This installs the `client-a` and `client-b` console commands, allowing you to run
+the clients with `client-a` or `client-b` from any location.
+
 ### Clone the Repository 📥
 ```bash
 git clone https://github.com/<your-username>/OnionChat.git

--- a/client_a_main.py
+++ b/client_a_main.py
@@ -14,6 +14,12 @@ def parse_args(argv=None):
     return parser.parse_args(argv)
 
 
+def main(argv=None):
+    """Entry point for the ``client-a`` console script."""
+    args = parse_args(argv)
+    client_a_main(args)
+
+
 if __name__ == "__main__":
     args = parse_args()
     client_a_main(args)

--- a/client_b_main.py
+++ b/client_b_main.py
@@ -15,6 +15,15 @@ def parse_args(argv=None):
     return parser.parse_args(argv)
 
 
+def main(argv=None):
+    """Entry point for the ``client-b`` console script."""
+    args = parse_args(argv)
+    if args.onion and args.session and args.key:
+        client_b_main(args.onion, args.session, args.key, args)
+    else:
+        client_b_setup(args)
+
+
 if __name__ == "__main__":
     args = parse_args()
     if args.onion and args.session and args.key:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "onionchat"
+version = "0.1.0"
+description = "Secure one-time chat over Tor"
+authors = [{name = "OnionChat Developers"}]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "torpy==1.1.5",
+    "cryptography==41.0.3",
+    "qrcode==7.4.2",
+    "pyzbar==0.1.9",
+    "opencv-python==4.8.1.78",
+    "Pillow==10.0.0",
+    "pyperclip==1.8.2",
+]
+
+[project.scripts]
+client-a = "client_a_main:main"
+client-b = "client_b_main:main"
+
+[tool.setuptools]
+py-modules = [
+    "chat_utils",
+    "client_a",
+    "client_a_main",
+    "client_b",
+    "client_b_main",
+    "main",
+]
+


### PR DESCRIPTION
## Summary
- add `pyproject.toml` for packaging
- add `main()` entry points for client scripts
- document installation via pip

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686bc287790c8332870037b3e4626ea2