### PR TITLE
Add secure memory wipe extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+*.pyo
+*.so
+build/
+build.log
+.pytest_cache/
+_wiper.cpython-*.so

--- a/_wiper.c
+++ b/_wiper.c
@@ -1,0 +1,33 @@
+#include <Python.h>
+#include <string.h>
+
+static PyObject* wipe(PyObject* self, PyObject* obj) {
+    Py_buffer view;
+    if (PyObject_GetBuffer(obj, &view, PyBUF_WRITABLE) != 0) {
+        return NULL;  // propagate exception if object does not support buffer protocol
+    }
+    volatile unsigned char *p = (volatile unsigned char *)view.buf;
+    Py_ssize_t len = view.len;
+    for (Py_ssize_t i = 0; i < len; i++) {
+        p[i] = 0;
+    }
+    PyBuffer_Release(&view);
+    Py_RETURN_NONE;
+}
+
+static PyMethodDef Methods[] = {
+    {"wipe", (PyCFunction)wipe, METH_O, "Overwrite a writable buffer with zeros"},
+    {NULL, NULL, 0, NULL}
+};
+
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "_wiper",
+    "Memory wiping utilities",
+    -1,
+    Methods
+};
+
+PyMODINIT_FUNC PyInit__wiper(void) {
+    return PyModule_Create(&moduledef);
+}

--- a/chat_utils.py
+++ b/chat_utils.py
@@ -11,6 +11,11 @@ from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from PIL import ImageTk
 
 try:
+    from _wiper import wipe as c_wipe
+except Exception:  # pragma: no cover - optional C module
+    c_wipe = None
+
+try:
     from torpy import TorClient
 except Exception:  # pragma: no cover - network dependency
     TorClient = None
@@ -46,11 +51,14 @@ def secure_wipe(data):
             ba = bytearray(data)
         else:
             ba = data
-        rnd = secrets.token_bytes(len(ba))
-        for i in range(len(ba)):
-            ba[i] = rnd[i]
-        for i in range(len(ba)):
-            ba[i] = 0
+        if c_wipe is not None:
+            c_wipe(ba)
+        else:
+            rnd = secrets.token_bytes(len(ba))
+            for i in range(len(ba)):
+                ba[i] = rnd[i]
+            for i in range(len(ba)):
+                ba[i] = 0
     except Exception:
         pass
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,6 @@
+from setuptools import setup, Extension
+
+setup(
+    name="wiper", 
+    ext_modules=[Extension("_wiper", ["_wiper.c"])]
+)


### PR DESCRIPTION
## Summary
- add `_wiper` C extension providing memory wipe routine
- integrate extension in `chat_utils.secure_wipe`
- provide `setup.py` and ignore build artifacts

## Testing
- `python setup.py build_ext --inplace`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bc2888b8883328570e88128ed525d