### PR TITLE
Fix PyInstaller startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,12 @@ OnionChat can be compiled into standalone executables for Linux, Windows, and ma
 2. **Compile the Binaries**:
    - Build Client A:
      ```bash
-     pyinstaller --onefile onionchat/client_a_main.py
+     pyinstaller --onefile -m onionchat.client_a_main
      ```
      This creates `dist/client_a_main` (`client_a.exe` on Windows).
    - Build Client B:
      ```bash
-     pyinstaller --onefile onionchat/client_b_main.py
+     pyinstaller --onefile -m onionchat.client_b_main
      ```
      This creates `dist/client_b_main` (`client_b.exe` on Windows).
 3. **Platform-Specific Notes**:

--- a/onionchat/client_a_main.py
+++ b/onionchat/client_a_main.py
@@ -1,6 +1,6 @@
 """Entry script for OnionChat Client A."""
 import argparse
-from .client_a import client_a_main
+from onionchat.client_a import client_a_main
 
 
 def parse_args(argv=None):

--- a/onionchat/client_b_main.py
+++ b/onionchat/client_b_main.py
@@ -1,6 +1,6 @@
 """Entry script for OnionChat Client B."""
 import argparse
-from .client_b import client_b_main, client_b_setup
+from onionchat.client_b import client_b_main, client_b_setup
 
 
 def parse_args(argv=None):

--- a/onionchat/main.py
+++ b/onionchat/main.py
@@ -31,8 +31,8 @@ def check_dependencies():
             "Install them with `pip install -r requirements.txt`."
         )
 
-from .client_a import client_a_main
-from .client_b import client_b_setup
+from onionchat.client_a import client_a_main
+from onionchat.client_b import client_b_setup
 
 
 def parse_args():
@@ -56,7 +56,7 @@ if __name__ == "__main__":
         client_a_main(args)
     else:
         if args.onion and args.session and args.key:
-            from . import client_b as _client_b
+            from onionchat import client_b as _client_b
             _client_b.client_b_main(args.onion, args.session, args.key, args)
         else:
             client_b_setup(args)


### PR DESCRIPTION
## Summary
- convert relative imports to absolute module imports so PyInstaller-built binaries run
- update PyInstaller instructions to use module form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686be00a18e48332a0cfd6bbd881bf12