### PR TITLE
Fix Pillow dependency for Python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "qrcode==7.4.2",
     "pyzbar==0.1.9",
     "opencv-python==4.8.1.78",
-    "Pillow==10.0.0",
+    "Pillow==11.3.0",
     "pyperclip==1.8.2",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ cryptography==41.0.3
 qrcode==7.4.2
 pyzbar==0.1.9
 opencv-python==4.8.1.78
-Pillow==10.0.0
+Pillow==11.3.0
 pyperclip==1.8.2


### PR DESCRIPTION
## Summary
- update Pillow requirement to version 11.3.0 in `requirements.txt` and `pyproject.toml`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686be1e54bb883328f277b6505e3b511