### PR TITLE
Pin numpy<2 for Python 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ OnionChat is a secure, anonymous, one-time chat messenger built with Python. It 
 ## Installation 🛠️
 
 ### Prerequisites ✅
-- Python 3.10 or higher
+- Python 3.10 or higher (Python 3.13 users must install **NumPy <2**, or use Python ≤3.12)
 - A graphical environment (e.g., X11 on Linux, Windows GUI, macOS)
 - Internet connection for Tor network access
 - Optional: Webcam for QR code scanning 📸

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "opencv-python==4.8.1.78",
     "Pillow==11.3.0",
     "pyperclip==1.8.2",
+    "numpy<2",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyzbar==0.1.9
 opencv-python==4.8.1.78
 Pillow==11.3.0
 pyperclip==1.8.2
+numpy<2


### PR DESCRIPTION
## Summary
- pin numpy<2 in requirements and pyproject
- warn Python 3.13 users that numpy<2 is required

## Testing
- `pip install -r requirements.txt --force-reinstall`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686be87e36988332a880d7add634798a