### PR TITLE
Fix ECDH serialization for cryptography 42

### DIFF
--- a/onionchat/chat_utils.py
+++ b/onionchat/chat_utils.py
@@ -76,7 +76,7 @@ def generate_keys():
     ecdh_private = x25519.X25519PrivateKey.generate()
     ecdh_public = ecdh_private.public_key()
     ecdh_bytes = ecdh_public.public_bytes(
-        encoding=serialization.Raw,
+        encoding=serialization.Encoding.Raw,
         format=serialization.PublicFormat.Raw,
     )
     return rsa_private, rsa_public, rsa_bytes, ecdh_private, ecdh_bytes

--- a/onionchat/client_b.py
+++ b/onionchat/client_b.py
@@ -86,7 +86,7 @@ def client_b_main(onion_hostname: str, session_id: str, public_key_file: str, ar
 
     ecdh_private_key = x25519.X25519PrivateKey.generate()
     ecdh_public_bytes = ecdh_private_key.public_key().public_bytes(
-        encoding=serialization.Raw,
+        encoding=serialization.Encoding.Raw,
         format=serialization.PublicFormat.Raw,
     )
     encrypted_key = rsa_public_key.encrypt(


### PR DESCRIPTION
## Summary
- fix ECDH key serialization constants for cryptography 42

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_686be9a01a608332b46bd426ec08e665