### PR TITLE
Add logo display to README and startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # OnionChat 🧅💬
 
+<p align="center">
+  <img src="Logo/onionchat_logo.png" alt="OnionChat Logo" width="200" />
+</p>
+
 OnionChat is a secure, anonymous, one-time chat messenger built with Python. It leverages Tor hidden services for anonymity, RSA-4096 and ECDH (Curve25519) for key exchange with forward secrecy, AES-256-GCM for message encryption, and a user-friendly GUI with QR code-based credential sharing. Designed for private, ephemeral communication, OnionChat ensures no persistent data is stored, with a kill switch controlled by Client A to prevent reconnection. 🔒🚀
 
 ## Features 🌟

--- a/onionchat/client_a.py
+++ b/onionchat/client_a.py
@@ -11,6 +11,20 @@ from tkinter import filedialog, messagebox
 from tkinter.scrolledtext import ScrolledText
 from queue import Queue
 
+
+def _add_logo(root: tk.Tk) -> None:
+    """Display the OnionChat logo if available."""
+    logo_path = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "Logo", "onionchat_logo.png")
+    )
+    if os.path.exists(logo_path):
+        try:
+            logo_img = tk.PhotoImage(file=logo_path)
+            root.logo_img = logo_img  # prevent garbage collection
+            tk.Label(root, image=logo_img).pack(pady=5)
+        except Exception:
+            pass
+
 from cryptography.hazmat.primitives import (
     hashes,
     padding as asym_padding,
@@ -72,6 +86,7 @@ def client_a_main(args):
     root = tk.Tk()
     root.title("Client A - Secure Chat")
     root.geometry("600x400")
+    _add_logo(root)
 
     rsa_private, _, rsa_public_bytes, ecdh_private, ecdh_public_bytes = (
         generate_keys()

--- a/onionchat/client_b.py
+++ b/onionchat/client_b.py
@@ -8,6 +8,20 @@ from tkinter import filedialog, messagebox
 from tkinter.scrolledtext import ScrolledText
 from queue import Queue
 
+
+def _add_logo(root: tk.Tk) -> None:
+    """Display the OnionChat logo if available."""
+    logo_path = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "Logo", "onionchat_logo.png")
+    )
+    if os.path.exists(logo_path):
+        try:
+            logo_img = tk.PhotoImage(file=logo_path)
+            root.logo_img = logo_img  # keep reference
+            tk.Label(root, image=logo_img).pack(pady=5)
+        except Exception:
+            pass
+
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import (
     padding as asym_padding,
@@ -79,6 +93,7 @@ def client_b_main(
     root = tk.Tk()
     root.title("Client B - Secure Chat")
     root.geometry("600x400")
+    _add_logo(root)
 
     try:
         with open(public_key_file, "rb") as f:
@@ -453,6 +468,7 @@ def client_b_setup(args):
     root = tk.Tk()
     root.title("Client B Setup")
     root.geometry("400x300")
+    _add_logo(root)
 
     tk.Label(root, text="Onion Address:").pack(pady=5)
     onion_entry = tk.Entry(root, width=50)


### PR DESCRIPTION
## Summary
- show OnionChat logo in README
- display the logo when the GUI clients start

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d44d1b9a48332a1b6471918bbd536