### PR TITLE
Improve tor startup error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ OnionChat can be compiled into standalone executables for Linux, Windows, and ma
      pyinstaller --onefile --windowed -m onionchat.client_a_main
      ```
      This creates `dist/client_a_main` (`client_a.exe` on Windows).
+     (Older instructions mistakenly used `onion.client_a_main`; be sure to use
+     ``onionchat.client_a_main``.)
    - Build Client B:
      ```bash
      pyinstaller --onefile --windowed -m onionchat.client_b_main

--- a/onionchat/chat_utils.py
+++ b/onionchat/chat_utils.py
@@ -324,6 +324,11 @@ def setup_hidden_service(port: int, use_stem: bool = False):
                     tor_path = path
                     break
 
+    # Fall back to the 'tor' executable if no path was found. ``stem`` expects a
+    # string path and will raise a ``TypeError`` if ``None`` is provided.
+    if tor_path is None:
+        tor_path = "tor"
+
     try:
         try:
             ctrl = Controller.from_port()


### PR DESCRIPTION
## Summary
- better fallback to `tor` executable when TOR_PATH isn't set
- clarify build instructions for PyInstaller in README
- mention older instructions used wrong module path

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d4d6d719883329b67c409ee004f69