### PR TITLE
Add compile convenience script

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,13 @@ OnionChat can be compiled into standalone executables for Linux, Windows, and ma
      pyinstaller --onefile --windowed -m onionchat.client_b_main
      ```
      This creates `dist/client_b_main` (`client_b.exe` on Windows).
+
+For a one-step build you can run:
+```bash
+bash compile.sh
+```
+This script installs dependencies, compiles the optional C extension, and places the executables in `dist/`.
+
    - Pass `--windowed` (or `--noconsole` on Windows) to hide the command prompt
      and launch the GUI directly.
 3. **Platform-Specific Notes**:

--- a/compile.sh
+++ b/compile.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Build OnionChat executables.
+set -e
+
+# Ensure we're in the repo root
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Install Python package requirements and PyInstaller
+pip install -r requirements.txt pyinstaller
+
+# Build optional C extension
+python setup.py build_ext --inplace
+
+# Build Client A and Client B executables
+pyinstaller --onefile --windowed -m onionchat.client_a_main -n client_a_main
+pyinstaller --onefile --windowed -m onionchat.client_b_main -n client_b_main
+
+echo "Executables are available in the dist/ directory."


### PR DESCRIPTION
## Summary
- add a `compile.sh` script that installs requirements and builds PyInstaller binaries
- document the new script in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d5b9cdcd48332bd6a4d3b62ec7187