### PR TITLE
Add Windows compile script

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,13 @@ OnionChat can be compiled into standalone executables for Linux, Windows, and ma
 
 For a one-step build you can run:
 ```bash
-bash compile.sh
+bash compile.sh  # Linux/macOS
 ```
-This script installs dependencies, compiles the optional C extension, and places the executables in `dist/`.
+On Windows use PowerShell:
+```powershell
+./compile.ps1
+```
+These scripts install dependencies, compile the optional C extension, and place the executables in `dist/`.
 
    - Pass `--windowed` (or `--noconsole` on Windows) to hide the command prompt
      and launch the GUI directly.

--- a/compile.ps1
+++ b/compile.ps1
@@ -1,0 +1,19 @@
+# PowerShell script to build OnionChat executables on Windows
+# Ensure execution stops on errors
+$ErrorActionPreference = 'Stop'
+
+# Switch to the directory containing this script
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+Set-Location $scriptDir
+
+# Install required Python packages and PyInstaller
+pip install -r requirements.txt pyinstaller
+
+# Build optional C extension
+python setup.py build_ext --inplace
+
+# Build Client A and Client B executables
+pyinstaller --onefile --windowed -m onionchat.client_a_main -n client_a_main
+pyinstaller --onefile --windowed -m onionchat.client_b_main -n client_b_main
+
+Write-Host "Executables are available in the dist/ directory."


### PR DESCRIPTION
## Summary
- add PowerShell script `compile.ps1` for building on Windows
- document Windows script usage in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d5d96580c8332b0545d848fbc5346