### PR TITLE
Ensure compile scripts invoke PyInstaller via module

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,17 +136,17 @@ OnionChat can be compiled into standalone executables for Linux, Windows, and ma
 
    ```
 2. **Compile the Binaries**:
-   - Build Client A:
-     ```bash
-     pyinstaller --onefile --windowed -m onionchat.client_a_main
-     ```
+  - Build Client A:
+    ```bash
+    python -m PyInstaller --onefile --windowed -m onionchat.client_a_main
+    ```
      This creates `dist/client_a_main` (`client_a.exe` on Windows).
      (Older instructions mistakenly used `onion.client_a_main`; be sure to use
      ``onionchat.client_a_main``.)
-   - Build Client B:
-     ```bash
-     pyinstaller --onefile --windowed -m onionchat.client_b_main
-     ```
+  - Build Client B:
+    ```bash
+    python -m PyInstaller --onefile --windowed -m onionchat.client_b_main
+    ```
      This creates `dist/client_b_main` (`client_b.exe` on Windows).
 
 For a one-step build you can run:

--- a/compile.ps1
+++ b/compile.ps1
@@ -13,7 +13,7 @@ pip install -r requirements.txt pyinstaller
 python setup.py build_ext --inplace
 
 # Build Client A and Client B executables
-pyinstaller --onefile --windowed -m onionchat.client_a_main -n client_a_main
-pyinstaller --onefile --windowed -m onionchat.client_b_main -n client_b_main
+python -m PyInstaller --onefile --windowed -m onionchat.client_a_main -n client_a_main
+python -m PyInstaller --onefile --windowed -m onionchat.client_b_main -n client_b_main
 
 Write-Host "Executables are available in the dist/ directory."

--- a/compile.sh
+++ b/compile.sh
@@ -13,7 +13,7 @@ pip install -r requirements.txt pyinstaller
 python setup.py build_ext --inplace
 
 # Build Client A and Client B executables
-pyinstaller --onefile --windowed -m onionchat.client_a_main -n client_a_main
-pyinstaller --onefile --windowed -m onionchat.client_b_main -n client_b_main
+python -m PyInstaller --onefile --windowed -m onionchat.client_a_main -n client_a_main
+python -m PyInstaller --onefile --windowed -m onionchat.client_b_main -n client_b_main
 
 echo "Executables are available in the dist/ directory."


### PR DESCRIPTION
## Summary
- make compile scripts call `python -m PyInstaller`
- document PyInstaller invocation in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d65f1984083328497d8e33665aff1