### PR TITLE
Fix compile script paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,14 +138,13 @@ OnionChat can be compiled into standalone executables for Linux, Windows, and ma
 2. **Compile the Binaries**:
   - Build Client A:
     ```bash
-    python -m PyInstaller --onefile --windowed -m onionchat.client_a_main
+    python -m PyInstaller --onefile --windowed onionchat/client_a_main.py
     ```
      This creates `dist/client_a_main` (`client_a.exe` on Windows).
-     (Older instructions mistakenly used `onion.client_a_main`; be sure to use
-     ``onionchat.client_a_main``.)
+     (Older instructions used module notation like ``-m onionchat.client_a_main``.)
   - Build Client B:
     ```bash
-    python -m PyInstaller --onefile --windowed -m onionchat.client_b_main
+    python -m PyInstaller --onefile --windowed onionchat/client_b_main.py
     ```
      This creates `dist/client_b_main` (`client_b.exe` on Windows).
 

--- a/compile.ps1
+++ b/compile.ps1
@@ -13,7 +13,7 @@ pip install -r requirements.txt pyinstaller
 python setup.py build_ext --inplace
 
 # Build Client A and Client B executables
-python -m PyInstaller --onefile --windowed -m onionchat.client_a_main -n client_a_main
-python -m PyInstaller --onefile --windowed -m onionchat.client_b_main -n client_b_main
+python -m PyInstaller --onefile --windowed onionchat/client_a_main.py -n client_a_main
+python -m PyInstaller --onefile --windowed onionchat/client_b_main.py -n client_b_main
 
 Write-Host "Executables are available in the dist/ directory."

--- a/compile.sh
+++ b/compile.sh
@@ -13,7 +13,7 @@ pip install -r requirements.txt pyinstaller
 python setup.py build_ext --inplace
 
 # Build Client A and Client B executables
-python -m PyInstaller --onefile --windowed -m onionchat.client_a_main -n client_a_main
-python -m PyInstaller --onefile --windowed -m onionchat.client_b_main -n client_b_main
+python -m PyInstaller --onefile --windowed onionchat/client_a_main.py -n client_a_main
+python -m PyInstaller --onefile --windowed onionchat/client_b_main.py -n client_b_main
 
 echo "Executables are available in the dist/ directory."


### PR DESCRIPTION
## Summary
- fix pyinstaller targets to use script paths
- document new compile commands in the README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d6961012883328cb5b87968e51fbd