### PR TITLE
Fix Tor bundle extraction path

### DIFF
--- a/onionchat/chat_utils.py
+++ b/onionchat/chat_utils.py
@@ -98,15 +98,15 @@ def _download_tor_bundle(dest_dir: str) -> str | None:
             urllib.request.urlretrieve(url, archive)
         with tarfile.open(archive, "r:gz") as tar:
             tar.extractall(dest_dir)
-        bundle_dir = os.path.join(dest_dir, file_name[:-7])
-        tor_bin = os.path.join(
-            bundle_dir,
-            "Tor",
-            "tor.exe" if system == "Windows" else "tor",
-        )
-        if os.path.exists(tor_bin):
-            os.chmod(tor_bin, 0o755)
-            return tor_bin
+        for base in [os.path.join(dest_dir, file_name[:-7]), dest_dir]:
+            tor_bin = os.path.join(
+                base,
+                "tor",
+                "tor.exe" if system == "Windows" else "tor",
+            )
+            if os.path.exists(tor_bin):
+                os.chmod(tor_bin, 0o755)
+                return tor_bin
     except Exception:
         return None
     return None
@@ -121,7 +121,7 @@ def _ensure_tor() -> str | None:
         return tor_path
     candidate = os.path.join(
         tor_dir,
-        "Tor",
+        "tor",
         "tor.exe" if os.name == "nt" else "tor",
     )
     if os.path.exists(candidate):

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -34,3 +34,30 @@ def test_client_b_default_args():
     assert args.session is None
     assert args.key is None
 
+
+def test_download_tor_bundle(monkeypatch, tmp_path):
+    import tarfile
+    import shutil
+    import urllib.request
+    import platform
+    from onionchat.chat_utils import _download_tor_bundle
+
+    tarball = tmp_path / "tor-expert-bundle-linux-x86_64-14.5.4.tar.gz"
+    tor_inner = tmp_path / "tor_inner" / "tor"
+    tor_inner.mkdir(parents=True)
+    (tor_inner / "tor").write_text("dummy")
+    with tarfile.open(tarball, "w:gz") as tar:
+        tar.add(tor_inner, arcname="tor")
+
+    def fake_retrieve(url, dest):
+        shutil.copy(tarball, dest)
+
+    monkeypatch.setattr(urllib.request, "urlretrieve", fake_retrieve)
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr(platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(os, "chmod", lambda *a, **k: None)
+
+    dest = _download_tor_bundle(str(tmp_path))
+    assert dest and dest.endswith("tor")
+    assert os.path.exists(dest)
+


### PR DESCRIPTION
## Summary
- locate downloaded Tor expert bundle correctly
- support both tarball layouts
- test download logic with a mocked bundle

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e5512d0688332b602d4f20651a1d5